### PR TITLE
Refactor implementation for major performance improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,29 +15,25 @@ jobs:
       uses: actions/checkout@v2
     -
       name: Setup Lua
-      uses: leafo/gh-actions-lua@v8
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
+      uses: mah0x211/setup-lua@v1
     -
       name: Install Tools
       run: luarocks install luacheck
     -
       name: Run luacheck
       run: |
-        luacheck .
+        luacheck --no-self .
 
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         lua-version:
-          - "5.1"
-          - "5.2"
-          - "5.3"
-          - "5.4"
-          - "luajit-openresty"
-          - "luajit-2.0.5"
+          - "5.1.:latest"
+          - "5.2.:latest"
+          - "5.3.:latest"
+          - "5.4.:latest"
+          - "lj-v2.1:latest"
     steps:
     -
       name: Checkout
@@ -46,12 +42,9 @@ jobs:
         submodules: 'true'
     -
       name: Setup Lua ${{ matrix.lua-version }}
-      uses: leafo/gh-actions-lua@v8
+      uses: mah0x211/setup-lua@v1
       with:
-        luaVersion: ${{ matrix.lua-version }}
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
+        versions: ${{ matrix.lua-version }}
     -
       name: Install
       run: |
@@ -72,6 +65,7 @@ jobs:
         sh ./covgen.sh
     -
       name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests

--- a/test/readn_test.lua
+++ b/test/readn_test.lua
@@ -58,30 +58,6 @@ function testcase.readn()
     assert.is_nil(again)
 end
 
-function testcase.read_with_16k_buf()
-    local f = assert(io.tmpfile())
-    f:write(string.rep('a', 24 * 1024))
-    f:seek('set')
-
-    -- test that read 18k bytes from a file using 16k buffer
-    local data, err, again = readn(f, 18 * 1024)
-    assert.is_nil(err)
-    assert.is_nil(again)
-    assert.equal(#data, 18 * 1024)
-end
-
-function testcase.read_with_8k_buf()
-    local f = assert(io.tmpfile())
-    f:write(string.rep('a', 24 * 1024))
-    f:seek('set')
-
-    -- test that read 18k bytes from a file using 16k buffer
-    local data, err, again = readn(f, 9 * 1024)
-    assert.is_nil(err)
-    assert.is_nil(again)
-    assert.equal(#data, 9 * 1024)
-end
-
 function testcase.read_from_fd()
     local f = assert(io.tmpfile())
     f:write('hello world')


### PR DESCRIPTION
This pull request refactors the implementation of the `readn` function in `src/readn.c` to simplify buffer management, improve error handling, and enhance compatibility across Lua versions. It also updates the GitHub Actions workflow to use a new Lua setup action and makes minor improvements to test coverage reporting.

**Refactoring and simplification of `readn` implementation:**

* Replaces the previous buffer size selection logic and multiple read loop functions with a unified approach that dynamically allocates and resizes buffers as needed, improving memory handling and reducing code duplication. Error handling is now more robust, with better differentiation of error types and messages. [[1]](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9R22-R185) [[2]](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9L213-L230)
* Automatically determines the read size for regular files using `fstat` if not explicitly provided, and simplifies the logic for reading all data when the count is zero or unspecified.
* Removes buffer-size-specific tests from `test/readn_test.lua` as the buffer management logic has been unified and no longer depends on fixed buffer sizes.

**Continuous Integration (CI) improvements:**

* Updates the GitHub Actions workflow to use `mah0x211/setup-lua@v1` for setting up Lua, replacing the deprecated `leafo/gh-actions-lua` and updating the matrix of Lua versions accordingly. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L18-R36) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L49-R47)
* Updates the Codecov action to v4 and adds the required token for coverage uploads.