### PR TITLE
Sync file position after read operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ luarocks install io-readn
 the following functions return the `error` object created by https://github.com/mah0x211/lua-errno module.
 
 
-## data, err = readn( file [, count] )
+## data, err, again = readn( file [, count] )
 
-open the lua file handle from a pathname or descriptor of the file.
+Reads data from the specified file handle or file descriptor.
 
 **Parameters**
 


### PR DESCRIPTION
This pull request refactors the `readn.c` implementation to improve memory management, error handling, and add better support for working with both file descriptors and `FILE*` streams. The core logic for reading data is now centralized in a `read_result_t` structure, and the code synchronizes the file position between `read()` and `FILE*` when both are used together.

Key changes include:

**Refactoring and Structure Improvements:**

* Introduced `FILE *fp` and `int fd` fields to the `read_result_t` struct to track both the file stream and descriptor, enabling unified handling of both types of input.
* Refactored the reading logic to use a single `read_result_t` struct, improving memory safety and error reporting throughout the read functions.

**File Position Synchronization:**

* Added logic in `pushresult` to synchronize the position of a `FILE*` stream with the underlying file descriptor after a read operation, ensuring consistency when mixing `read()` and standard I/O.

**Error Handling and Memory Management:**

* Improved error handling for memory allocation failures and file operations, ensuring resources are freed and errors are reported correctly to Lua.

These changes make the module more robust, flexible, and maintainable.