### PR TITLE
Add offset parameter support with pread() for positional reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ luarocks install io-readn
 the following functions return the `error` object created by https://github.com/mah0x211/lua-errno module.
 
 
-## data, err, again = readn( file [, count] )
+## data, err, again = readn( file [, count [, offset]] )
 
 Reads data from the specified file handle or file descriptor.
 
@@ -27,6 +27,7 @@ Reads data from the specified file handle or file descriptor.
 
 - `file:file*|integer`: a file handle or a file descriptor.
 - `count:integer`: the number of bytes to read. if the `count` is not specified, then it will be read until the end of the file. (default: `nil`)
+- `offset:integer`: the offset in bytes from the beginning of the file to start reading. if the `offset` is specified, then the file position will be moved to the specified offset before reading. (default: `nil`)
 
 **Returns**
 

--- a/test/readn_test.lua
+++ b/test/readn_test.lua
@@ -70,3 +70,65 @@ function testcase.read_from_fd()
     assert.is_nil(again)
     assert.equal(data, 'hello world')
 end
+
+function testcase.read_with_offset()
+    local f = assert(io.tmpfile())
+    f:write('hello world')
+
+    -- verify initial position
+    f:seek('set')
+    local pos = f:seek()
+    assert.equal(pos, 0)
+
+    -- test normal read (no offset) first to confirm position advancement
+    local data, err, again = readn(f, 3)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(data, 'hel')
+
+    -- verify file position has advanced after normal read
+    pos = f:seek()
+    assert.equal(pos, 3)
+
+    -- test that read with offset 0 (using pread internally)
+    data, err, again = readn(f, 5, 0)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(data, 'hello')
+
+    -- verify file position hasn't changed after offset read
+    pos = f:seek()
+    assert.equal(pos, 3)
+
+    -- test another normal read to confirm position advancement
+    data, err, again = readn(f, 2)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(data, 'lo')
+
+    -- verify file position advanced again
+    pos = f:seek()
+    assert.equal(pos, 5)
+
+    -- test that read with offset 2
+    data, err, again = readn(f, 5, 2)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(data, 'llo w')
+
+    -- verify file position still at 5 after offset read
+    pos = f:seek()
+    assert.equal(pos, 5)
+
+    -- test that read with offset at end of file
+    data, err, again = readn(f, 5, 11)
+    assert.is_nil(data)
+    assert.is_nil(err)
+    assert.is_nil(again)
+
+    -- verify file position still at 5 after offset read at EOF
+    pos = f:seek()
+    assert.equal(pos, 5)
+
+    f:close()
+end


### PR DESCRIPTION
This pull request adds support for reading from a file descriptor or file at a specific offset using `pread`, without advancing the file position, and updates the test suite to verify this behavior. The main changes involve updating the read logic to accept an optional offset parameter, using `pread` when an offset is specified, and ensuring that file position is only advanced when reading without an explicit offset.

**Feature: Offset-based file reading**

* Added an `offset` field to the `read_result_t` struct and updated the internal `read_lua` and `readall_lua` functions to accept an `off_t offset` parameter, using `pread` when an offset is specified and `read` otherwise. This allows reading at a specific file offset without changing the file's current position. [[1]](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9R40) [[2]](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9L124-R130) [[3]](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9L143-R146) [[4]](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9L155-R165) [[5]](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9L177-R183)

* Updated the `readn_lua` function to accept an optional offset argument from Lua, passing it through to the internal read functions. The offset defaults to -1 (current position) if not provided. [[1]](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9R215) [[2]](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9R238-R244)

**Behavior: File position handling**

* Modified the logic in `pushresult` to only synchronize the `FILE*` position with the file descriptor if reading was done without an explicit offset (i.e., not using `pread`).

**Testing: Offset read verification**

* Added a new test case `read_with_offset` in `test/readn_test.lua` to verify that reading with an offset returns the correct data and does not advance the file position, while normal reads do advance the position. The test also checks reading at the end of the file with an offset.