### PR TITLE
Fix fflush error handling in readn_lua to ignore EBADF

### DIFF
--- a/src/readn.c
+++ b/src/readn.c
@@ -212,8 +212,10 @@ static int readn_lua(lua_State *L)
         fd = lauxh_checkint(L, 1);
     } else if (!(fp = lauxh_checkfile(L, 1))) {
         fd = -1;
-    } else if (fflush(fp) != 0) {
+    } else if (fflush(fp) != 0 && errno != EBADF) {
         // failed to flush FILE* buffer
+        // NOTE: ignore EBADF error which means the FILE* is not opened for
+        // writing
         lua_pushnil(L);
         lua_errno_new(L, errno, "readn");
         return 2;


### PR DESCRIPTION
This pull request makes a small but important change to the error handling logic in the `readn_lua` function. Specifically, it improves how errors from `fflush` are handled by ignoring the `EBADF` error, which indicates that the `FILE*` is not opened for writing.

- Improved error handling in `readn_lua` by ignoring `EBADF` errors from `fflush`, since this error simply means the file is not open for writing and should not be treated as a failure. (`src/readn.c`, [src/readn.cL215-R218](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9L215-R218))