### PR TITLE
Refactor error handling in readn functions for clarity

### DIFF
--- a/src/readn.c
+++ b/src/readn.c
@@ -63,7 +63,8 @@ static int pushlstring(lua_State *L)
         }
         // got error
         lua_pushnil(L);
-        lua_errno_new(L, res->err, "readn");
+        lua_errno_new(L, res->err,
+                      (res->err == ENOMEM) ? "read.alloc" : "read");
         return 2;
     }
     // eof
@@ -80,7 +81,7 @@ static int pushresult(lua_State *L, read_result_t *res)
             // fseek error
             free(res->buf);
             lua_pushnil(L);
-            lua_errno_new(L, errno, "readn.sync");
+            lua_errno_new(L, errno, "read.fseek");
             return 2;
         }
     }
@@ -117,7 +118,8 @@ static int pushresult(lua_State *L, read_result_t *res)
     case LUA_ERRMEM:
         // memory allocation error
         lua_pushnil(L);
-        lua_errno_new_with_message(L, ENOMEM, "read", lua_tostring(L, -2));
+        lua_errno_new_with_message(L, ENOMEM, "read.alloc",
+                                   lua_tostring(L, -2));
         return 2;
     }
 }
@@ -137,7 +139,7 @@ static int read_lua(lua_State *L, FILE *fp, int fd, size_t count, off_t offset)
     if (!res.buf) {
         // malloc error
         lua_pushnil(L);
-        lua_errno_new(L, errno, "readn");
+        lua_errno_new(L, errno, "read.alloc");
         return 2;
     }
 
@@ -173,7 +175,7 @@ static int readall_lua(lua_State *L, FILE *fp, int fd, off_t offset)
     if (!res.buf) {
         // malloc error
         lua_pushnil(L);
-        lua_errno_new(L, errno, "readn");
+        lua_errno_new(L, errno, "read.alloc");
         return 2;
     }
 
@@ -224,7 +226,7 @@ static int readn_lua(lua_State *L)
         // NOTE: ignore EBADF error which means the FILE* is not opened for
         // writing
         lua_pushnil(L);
-        lua_errno_new(L, errno, "readn");
+        lua_errno_new(L, errno, "read.fflush");
         return 2;
     } else {
         // get fd from FILE*


### PR DESCRIPTION
This pull request focuses on improving error reporting in the `src/readn.c` file by making error labels more descriptive and specific to the type of failure encountered. The changes help clarify the source of errors, especially distinguishing memory allocation errors from other read errors, and refining error tags for file operations.

**Error reporting improvements:**

* Changed error labels for memory allocation failures from `"readn"` or `"read"` to `"read.alloc"` throughout the code, making it clear when an error is due to allocation issues. [[1]](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9L66-R67) [[2]](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9L120-R122) [[3]](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9L140-R142) [[4]](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9L176-R178)
* Updated the error label for `fseek` failures from `"readn.sync"` to `"read.fseek"` for more accurate reporting of file seeking errors.
* Changed the error label for `fflush` failures from `"readn"` to `"read.fflush"` to specify the exact operation that failed.