### PR TITLE
Eliminate automatic retries for interrupted system calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Reads data from the specified file handle or file descriptor.
 
 - `data:string`: read data.
 - `err:any`: error object.
-- `again:boolean`: `true` if the read operation is incomplete and the `data` is not available.
+- `again:boolean`: `true` if the read operation is incomplete (read syscall returned `EAGAIN`, `EWOULDBLOCK`, or `EINTR`) and the `data` is not available.
 
 
 ## Usage


### PR DESCRIPTION
This pull request improves error handling when performing file reads, specifically by handling the `EINTR` error consistently alongside `EAGAIN` and `EWOULDBLOCK`. It also updates the documentation to clarify the meaning of the `again` return value.

**Error handling improvements:**

* Added handling for the `EINTR` error in the read result, so that `again` is set to `true` if the read syscall returns `EINTR`, in addition to `EAGAIN` and `EWOULDBLOCK`. (`src/readn.c`)
* Removed retry logic for `EINTR` in both `read_lua` and `readall_lua` functions, so that `EINTR` is now treated like other incomplete read errors rather than being retried automatically. (`src/readn.c`) [[1]](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9L146-L152) [[2]](diffhunk://#diff-53df0da57eafcd716ffec76538f3c7c33eccaf1e092b45bb79565674ab6e03e9L201-L203)

**Documentation updates:**

* Clarified in the `README.md` that `again` is `true` if the read operation is incomplete due to `EAGAIN`, `EWOULDBLOCK`, or `EINTR`. (`README.md`)