### PR TITLE
Change module name to io-read

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
     -
       name: Install
       run: |
-        luarocks make IO_READN_COVERAGE=1
+        luarocks make rockspecs/io-read-dev-1.rockspec IO_READ_COVERAGE=1
     -
       name: Install Tools
       run: |

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SRCS=$(wildcard src/*.c)
 SOBJ=$(SRCS:.c=.$(LIB_EXTENSION))
 INSTALL?=install
 
-ifdef IO_READN_COVERAGE
+ifdef IO_READ_COVERAGE
 COVFLAGS="--coverage"
 endif
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# lua-io-readn
+# lua-io-read
 
-[![test](https://github.com/mah0x211/lua-io-readn/actions/workflows/test.yml/badge.svg)](https://github.com/mah0x211/lua-io-readn/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/mah0x211/lua-io-readn/branch/master/graph/badge.svg)](https://codecov.io/gh/mah0x211/lua-io-readn)
+[![test](https://github.com/mah0x211/lua-io-read/actions/workflows/test.yml/badge.svg)](https://github.com/mah0x211/lua-io-read/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/mah0x211/lua-io-read/branch/master/graph/badge.svg)](https://codecov.io/gh/mah0x211/lua-io-read)
 
 Reads data from a specified file descriptor.
 
@@ -9,7 +9,7 @@ Reads data from a specified file descriptor.
 ## Installation
 
 ```
-luarocks install io-readn
+luarocks install io-read
 ```
 
 ---
@@ -19,7 +19,7 @@ luarocks install io-readn
 the following functions return the `error` object created by https://github.com/mah0x211/lua-errno module.
 
 
-## data, err, again = readn( file [, count [, offset]] )
+## data, err, again = read( file [, count [, offset]] )
 
 Reads data from the specified file handle or file descriptor.
 
@@ -39,11 +39,11 @@ Reads data from the specified file handle or file descriptor.
 ## Usage
 
 ```lua
-local readn = require('io.readn')
+local read = require('io.read')
 local f = assert(io.open('./test.txt'))
 
 -- read 10 bytes from the file
-local data, err, again = readn(f, 10)
+local data, err, again = read(f, 10)
 if data then
     print(data)
 elseif again then

--- a/rockspecs/io-read-dev-1.rockspec
+++ b/rockspecs/io-read-dev-1.rockspec
@@ -1,11 +1,11 @@
-package = "io-readn"
+package = "io-read"
 version = "dev-1"
 source = {
-    url = "git+https://github.com/mah0x211/lua-io-readn.git",
+    url = "git+https://github.com/mah0x211/lua-io-read.git",
 }
 description = {
     summary = "Reads data from a specified file descriptor.",
-    homepage = "https://github.com/mah0x211/lua-io-readn",
+    homepage = "https://github.com/mah0x211/lua-io-read",
     license = "MIT/X11",
     maintainer = "Masatoshi Fukunaga",
 }
@@ -22,7 +22,7 @@ build = {
         WARNINGS = "-Wall -Wno-trigraphs -Wmissing-field-initializers -Wreturn-type -Wmissing-braces -Wparentheses -Wno-switch -Wunused-function -Wunused-label -Wunused-parameter -Wunused-variable -Wunused-value -Wuninitialized -Wunknown-pragmas -Wshadow -Wsign-compare",
         CPPFLAGS = "-I$(LUA_INCDIR)",
         LDFLAGS = "$(LIBFLAG)",
-        IO_READN_COVERAGE = "$(IO_READN_COVERAGE)",
+        IO_READ_COVERAGE = "$(IO_READ_COVERAGE)",
     },
     install_variables = {
         LIB_EXTENSION = "$(LIB_EXTENSION)",

--- a/rockspecs/io-readn-0.3.0-1.rockspec
+++ b/rockspecs/io-readn-0.3.0-1.rockspec
@@ -1,12 +1,12 @@
-package = "io-readn"
+package = "io-read"
 version = "0.3.0-1"
 source = {
-    url = "git+https://github.com/mah0x211/lua-io-readn.git",
+    url = "git+https://github.com/mah0x211/lua-io-read.git",
     tag = "v0.3.0",
 }
 description = {
     summary = "Reads data from a specified file descriptor.",
-    homepage = "https://github.com/mah0x211/lua-io-readn",
+    homepage = "https://github.com/mah0x211/lua-io-read",
     license = "MIT/X11",
     maintainer = "Masatoshi Fukunaga",
 }
@@ -23,7 +23,7 @@ build = {
         WARNINGS = "-Wall -Wno-trigraphs -Wmissing-field-initializers -Wreturn-type -Wmissing-braces -Wparentheses -Wno-switch -Wunused-function -Wunused-label -Wunused-parameter -Wunused-variable -Wunused-value -Wuninitialized -Wunknown-pragmas -Wshadow -Wsign-compare",
         CPPFLAGS = "-I$(LUA_INCDIR)",
         LDFLAGS = "$(LIBFLAG)",
-        IO_READN_COVERAGE = "$(IO_READN_COVERAGE)",
+        IO_READ_COVERAGE = "$(IO_READ_COVERAGE)",
     },
     install_variables = {
         LIB_EXTENSION = "$(LIB_EXTENSION)",

--- a/src/read.c
+++ b/src/read.c
@@ -125,7 +125,7 @@ static int pushresult(lua_State *L, read_result_t *res)
     }
 }
 
-static int read_lua(lua_State *L, FILE *fp, int fd, size_t count, off_t offset)
+static int readn_lua(lua_State *L, FILE *fp, int fd, size_t count, off_t offset)
 {
     read_result_t res = {
         .fp     = fp,
@@ -202,7 +202,7 @@ RETRY:
     return pushresult(L, &res);
 }
 
-static int readn_lua(lua_State *L)
+static int read_lua(lua_State *L)
 {
     struct stat st;
     FILE *fp     = NULL;
@@ -237,14 +237,14 @@ static int readn_lua(lua_State *L)
     offset = lauxh_optint(L, 3, -1);
 
     if (count > 0) {
-        return read_lua(L, fp, fd, count, offset);
+        return readn_lua(L, fp, fd, count, offset);
     }
     return readall_lua(L, fp, fd, offset);
 }
 
-LUALIB_API int luaopen_io_readn(lua_State *L)
+LUALIB_API int luaopen_io_read(lua_State *L)
 {
     lua_errno_loadlib(L);
-    lua_pushcfunction(L, readn_lua);
+    lua_pushcfunction(L, read_lua);
     return 1;
 }

--- a/test/read_test.lua
+++ b/test/read_test.lua
@@ -1,7 +1,7 @@
 local testcase = require('testcase')
 local assert = require('assert')
 local fileno = require('io.fileno')
-local readn = require('io.readn')
+local read = require('io.read')
 
 function testcase.readall()
     local f = assert(io.tmpfile())
@@ -9,50 +9,50 @@ function testcase.readall()
     f:seek('set')
 
     -- test that read all the content of a file
-    local data, err, again = readn(f)
+    local data, err, again = read(f)
     assert.is_nil(err)
     assert.is_nil(again)
     assert.equal(data, 'hello world')
 
     -- test that nil when EOF
-    data, err, again = readn(f)
+    data, err, again = read(f)
     assert.is_nil(data)
     assert.is_nil(err)
     assert.is_nil(again)
 
     -- test that return error when read from a closed file
     f:close()
-    data, err, again = readn(f)
+    data, err, again = read(f)
     assert.is_nil(data)
     assert.is_nil(again)
     assert.match(err, 'EBADF')
 end
 
-function testcase.readn()
+function testcase.read()
     local f = assert(io.tmpfile())
     f:write('hello world')
     f:seek('set')
 
     -- test that read 5 bytes from a file
-    local data, err, again = readn(f, 5)
+    local data, err, again = read(f, 5)
     assert.is_nil(err)
     assert.is_nil(again)
     assert.equal(data, 'hello')
 
     -- test that read 3 bytes from a file
-    data, err, again = readn(f, 3)
+    data, err, again = read(f, 3)
     assert.is_nil(err)
     assert.is_nil(again)
     assert.equal(data, ' wo')
 
     -- test that read remaining bytes from a file if n greater than file size
-    data, err, again = readn(f, 10)
+    data, err, again = read(f, 10)
     assert.is_nil(err)
     assert.is_nil(again)
     assert.equal(data, 'rld')
 
     -- test that return nil when EOF
-    data, err, again = readn(f, 10)
+    data, err, again = read(f, 10)
     assert.is_nil(data)
     assert.is_nil(err)
     assert.is_nil(again)
@@ -65,7 +65,7 @@ function testcase.read_from_fd()
     local fd = fileno(f)
 
     -- test that read 5 bytes from a file
-    local data, err, again = readn(fd)
+    local data, err, again = read(fd)
     assert.is_nil(err)
     assert.is_nil(again)
     assert.equal(data, 'hello world')
@@ -81,7 +81,7 @@ function testcase.read_with_offset()
     assert.equal(pos, 0)
 
     -- test normal read (no offset) first to confirm position advancement
-    local data, err, again = readn(f, 3)
+    local data, err, again = read(f, 3)
     assert.is_nil(err)
     assert.is_nil(again)
     assert.equal(data, 'hel')
@@ -91,7 +91,7 @@ function testcase.read_with_offset()
     assert.equal(pos, 3)
 
     -- test that read with offset 0 (using pread internally)
-    data, err, again = readn(f, 5, 0)
+    data, err, again = read(f, 5, 0)
     assert.is_nil(err)
     assert.is_nil(again)
     assert.equal(data, 'hello')
@@ -101,7 +101,7 @@ function testcase.read_with_offset()
     assert.equal(pos, 3)
 
     -- test another normal read to confirm position advancement
-    data, err, again = readn(f, 2)
+    data, err, again = read(f, 2)
     assert.is_nil(err)
     assert.is_nil(again)
     assert.equal(data, 'lo')
@@ -111,7 +111,7 @@ function testcase.read_with_offset()
     assert.equal(pos, 5)
 
     -- test that read with offset 2
-    data, err, again = readn(f, 5, 2)
+    data, err, again = read(f, 5, 2)
     assert.is_nil(err)
     assert.is_nil(again)
     assert.equal(data, 'llo w')
@@ -121,7 +121,7 @@ function testcase.read_with_offset()
     assert.equal(pos, 5)
 
     -- test that read with offset at end of file
-    data, err, again = readn(f, 5, 11)
+    data, err, again = read(f, 5, 11)
     assert.is_nil(data)
     assert.is_nil(err)
     assert.is_nil(again)


### PR DESCRIPTION
This pull request performs a comprehensive rename and rebranding of the project from `io-readn` to `io-read`. It updates all relevant code, documentation, build scripts, and test files to use the new name, and also standardizes the coverage environment variable. No functional changes to the core logic are introduced; the changes are organizational and naming-focused.

**Project Renaming and Branding:**

* Renamed the project throughout all documentation, including `README.md`, to use `io-read` instead of `io-readn`, and updated all references, badges, and installation instructions accordingly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R22) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R46)
* Renamed the main C source file from `src/readn.c` to `src/read.c`, and updated all Lua and C function names to use `read` instead of `readn`. The module is now required as `io.read` and the primary function is `read`. [[1]](diffhunk://#diff-d4b71621e3fb7422ad72c18339089f9626a0c48a95d4b71483bb18351bcd58c4L128-R128) [[2]](diffhunk://#diff-d4b71621e3fb7422ad72c18339089f9626a0c48a95d4b71483bb18351bcd58c4L205-R205) [[3]](diffhunk://#diff-d4b71621e3fb7422ad72c18339089f9626a0c48a95d4b71483bb18351bcd58c4L240-R248)
* Renamed and updated test files from `test/readn_test.lua` to `test/read_test.lua`, and replaced all references to `readn` with `read` in test cases. [[1]](diffhunk://#diff-25de1ca4d8f9fa46628778f3c60194cf79a95936482d15f15b3485f8d409a9aaL4-R55) [[2]](diffhunk://#diff-25de1ca4d8f9fa46628778f3c60194cf79a95936482d15f15b3485f8d409a9aaL68-R68) [[3]](diffhunk://#diff-25de1ca4d8f9fa46628778f3c60194cf79a95936482d15f15b3485f8d409a9aaL84-R84) [[4]](diffhunk://#diff-25de1ca4d8f9fa46628778f3c60194cf79a95936482d15f15b3485f8d409a9aaL94-R94) [[5]](diffhunk://#diff-25de1ca4d8f9fa46628778f3c60194cf79a95936482d15f15b3485f8d409a9aaL104-R104) [[6]](diffhunk://#diff-25de1ca4d8f9fa46628778f3c60194cf79a95936482d15f15b3485f8d409a9aaL114-R114) [[7]](diffhunk://#diff-25de1ca4d8f9fa46628778f3c60194cf79a95936482d15f15b3485f8d409a9aaL124-R124)

**Build and Packaging Updates:**

* Renamed rockspec files and updated their contents to reflect the new project name and repository URL (`io-read`), including both the dev and versioned rockspecs. [[1]](diffhunk://#diff-08ae82608bb8930c6b4ed1700892527202329b85185502b0b18b1c151340a37eL1-R8) [[2]](diffhunk://#diff-08ae82608bb8930c6b4ed1700892527202329b85185502b0b18b1c151340a37eL25-R25) [[3]](diffhunk://#diff-cfb80e46fa7e6e176aff9fab7e45cb9f3742fd8c197a4b74493aae48bd50e928L1-R9) [[4]](diffhunk://#diff-cfb80e46fa7e6e176aff9fab7e45cb9f3742fd8c197a4b74493aae48bd50e928L26-R26)
* Updated the GitHub Actions workflow and `Makefile` to use the new coverage environment variable `IO_READ_COVERAGE` instead of `IO_READN_COVERAGE`, and to refer to the new rockspec and naming. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L51-R51) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L5-R5)

These changes ensure consistency and clarity across the codebase and packaging, aligning everything under the new `io-read` name.