### PR TITLE
Update build configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,12 @@ on:
 jobs:
   luacheck:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     steps:
     -
       name: Checkout
       uses: actions/checkout@v2
-    -
-      name: Setup Lua
-      uses: mah0x211/setup-lua@v1
     -
       name: Install Tools
       run: luarocks install luacheck
@@ -26,6 +25,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     strategy:
       matrix:
         lua-version:
@@ -36,23 +37,23 @@ jobs:
           - "lj-v2.1:latest"
     steps:
     -
+      name: Switch Lua Version
+      run: |
+        lenv -g use ${{ matrix.lua-version }}
+        lua -v || true
+    -
       name: Checkout
       uses: actions/checkout@v2
       with:
         submodules: 'true'
     -
-      name: Setup Lua ${{ matrix.lua-version }}
-      uses: mah0x211/setup-lua@v1
-      with:
-        versions: ${{ matrix.lua-version }}
-    -
       name: Install
       run: |
-        luarocks make rockspecs/io-read-dev-1.rockspec IO_READ_COVERAGE=1
+        IO_READ_COVERAGE=1 luarocks make rockspecs/io-read-dev-1.rockspec
     -
       name: Install Tools
       run: |
-        sudo apt install lcov -y
+        apt-get install lcov -y
         luarocks install testcase
         luarocks install io-fileno
     -

--- a/rockspecs/io-read-0.3.0-1.rockspec
+++ b/rockspecs/io-read-0.3.0-1.rockspec
@@ -1,3 +1,4 @@
+rockspec_format = "3.0"
 package = "io-read"
 version = "0.3.0-1"
 source = {
@@ -15,18 +16,26 @@ dependencies = {
     "errno >= 0.5.0",
     "lauxhlib >= 0.6.0",
 }
+build_dependencies = {
+    "luarocks-build-hooks >= 0.6.0",
+    "configh >= 0.3.0",
+}
 build = {
-    type = "make",
-    build_variables = {
-        LIB_EXTENSION = "$(LIB_EXTENSION)",
-        CFLAGS = "$(CFLAGS)",
-        WARNINGS = "-Wall -Wno-trigraphs -Wmissing-field-initializers -Wreturn-type -Wmissing-braces -Wparentheses -Wno-switch -Wunused-function -Wunused-label -Wunused-parameter -Wunused-variable -Wunused-value -Wuninitialized -Wunknown-pragmas -Wshadow -Wsign-compare",
-        CPPFLAGS = "-I$(LUA_INCDIR)",
-        LDFLAGS = "$(LIBFLAG)",
-        IO_READ_COVERAGE = "$(IO_READ_COVERAGE)",
+    type = "hooks",
+    before_build = {
+        "$(extra-vars)",
+        "$(configh)",
     },
-    install_variables = {
-        LIB_EXTENSION = "$(LIB_EXTENSION)",
-        INST_LIBDIR = "$(LIBDIR)/io/",
+    extra_variables = {
+        CFLAGS = "-Wall -Wno-trigraphs -Wmissing-field-initializers -Wreturn-type -Wmissing-braces -Wparentheses -Wno-switch -Wunused-function -Wunused-label -Wunused-parameter -Wunused-variable -Wunused-value -Wuninitialized -Wunknown-pragmas -Wshadow -Wsign-compare",
+    },
+    conditional_variables = {
+        IO_READ_COVERAGE = {
+            CFLAGS = "--coverage",
+            LIBFLAG = "--coverage",
+        },
+    },
+    modules = {
+        ["io.read"] = "src/read.c",
     },
 }

--- a/rockspecs/io-read-dev-1.rockspec
+++ b/rockspecs/io-read-dev-1.rockspec
@@ -1,3 +1,4 @@
+rockspec_format = "3.0"
 package = "io-read"
 version = "dev-1"
 source = {
@@ -14,18 +15,26 @@ dependencies = {
     "errno >= 0.5.0",
     "lauxhlib >= 0.6.0",
 }
+build_dependencies = {
+    "luarocks-build-hooks >= 0.6.0",
+    "configh >= 0.3.0",
+}
 build = {
-    type = "make",
-    build_variables = {
-        LIB_EXTENSION = "$(LIB_EXTENSION)",
-        CFLAGS = "$(CFLAGS)",
-        WARNINGS = "-Wall -Wno-trigraphs -Wmissing-field-initializers -Wreturn-type -Wmissing-braces -Wparentheses -Wno-switch -Wunused-function -Wunused-label -Wunused-parameter -Wunused-variable -Wunused-value -Wuninitialized -Wunknown-pragmas -Wshadow -Wsign-compare",
-        CPPFLAGS = "-I$(LUA_INCDIR)",
-        LDFLAGS = "$(LIBFLAG)",
-        IO_READ_COVERAGE = "$(IO_READ_COVERAGE)",
+    type = "hooks",
+    before_build = {
+        "$(extra-vars)",
+        "$(configh)",
     },
-    install_variables = {
-        LIB_EXTENSION = "$(LIB_EXTENSION)",
-        INST_LIBDIR = "$(LIBDIR)/io/",
+    extra_variables = {
+        CFLAGS = "-Wall -Wno-trigraphs -Wmissing-field-initializers -Wreturn-type -Wmissing-braces -Wparentheses -Wno-switch -Wunused-function -Wunused-label -Wunused-parameter -Wunused-variable -Wunused-value -Wuninitialized -Wunknown-pragmas -Wshadow -Wsign-compare",
+    },
+    conditional_variables = {
+        IO_READ_COVERAGE = {
+            CFLAGS = "--coverage",
+            LIBFLAG = "--coverage",
+        },
+    },
+    modules = {
+        ["io.read"] = "src/read.c",
     },
 }


### PR DESCRIPTION
This pull request updates the build and CI setup for the project to modernize the workflow and improve compatibility with recent LuaRocks standards. The main changes are the migration of the build system in the rockspec files to use hooks instead of make, the addition of build dependencies, and updates to the GitHub Actions workflow to use a containerized environment.

**Build system modernization:**

* Migrated the build system in both `rockspecs/io-read-dev-1.rockspec` and `rockspecs/io-read-0.3.0-1.rockspec` from the legacy `make`-based approach to the new `hooks`-based system, and added `build_dependencies` for `luarocks-build-hooks` and `configh`. Also updated the module specification and build variables for better maintainability. [[1]](diffhunk://#diff-08ae82608bb8930c6b4ed1700892527202329b85185502b0b18b1c151340a37eR1) [[2]](diffhunk://#diff-08ae82608bb8930c6b4ed1700892527202329b85185502b0b18b1c151340a37eR18-R38) [[3]](diffhunk://#diff-9d44c647d8a4d1db3700779e618486649b12a19a565995555fee375eee5b0dd2R1) [[4]](diffhunk://#diff-9d44c647d8a4d1db3700779e618486649b12a19a565995555fee375eee5b0dd2R19-R39)

**CI workflow improvements:**

* Updated `.github/workflows/test.yml` to run jobs inside the `ghcr.io/mah0x211/lua-ci:latest` container for both `luacheck` and `test` jobs, removing the need for manual Lua setup steps. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R12-L18) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R28-R29)
* Modified the test job to switch Lua versions using `lenv`, and adjusted installation commands to work within the container environment.