### PR TITLE
Fix readn_lua crash on read/pread syscall failure

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -146,11 +146,11 @@ static int readn_lua(lua_State *L, FILE *fp, int fd, size_t count, off_t offset)
 
     nread = (offset < 0) ? read(fd, res.buf, count) :
                            pread(fd, res.buf, count, offset);
-    if (nread < 0) {
+    if (nread > 0) {
+        res.len = (size_t)nread;
+    } else if (nread < 0) {
         res.err = errno;
     }
-
-    res.len = (size_t)nread;
     return pushresult(L, &res);
 }
 

--- a/test/read_test.lua
+++ b/test/read_test.lua
@@ -58,6 +58,21 @@ function testcase.read()
     assert.is_nil(again)
 end
 
+function testcase.read_with_count_error()
+    local f = assert(io.tmpfile())
+    f:write('hello world')
+    f:seek('set')
+    f:close()
+
+    -- test that read with count returns error on closed file (EBADF)
+    -- before the fix, readn_lua() set res.len = (size_t)(-1) on failure,
+    -- causing lua_pushlstring to be called with a huge length → crash
+    local data, err, again = read(f, 5)
+    assert.is_nil(data)
+    assert.is_nil(again)
+    assert.match(err, 'EBADF')
+end
+
 function testcase.read_from_fd()
     local f = assert(io.tmpfile())
     f:write('hello world')
@@ -69,6 +84,29 @@ function testcase.read_from_fd()
     assert.is_nil(err)
     assert.is_nil(again)
     assert.equal(data, 'hello world')
+end
+
+function testcase.read_interleaved()
+    local f = assert(io.tmpfile())
+    f:write('foobarbaz')
+    f:seek('set')
+
+    -- test interleaved file:read() and read()
+    local first = f:read(3)
+    assert.equal(first, 'foo')
+
+    local data, err, again = read(f, 3)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(data, 'bar')
+
+    -- FILE* position must be resynced after read(), so f:read()
+    -- continues from the correct offset
+    local third = f:read(3)
+    assert.equal(third, 'baz')
+
+    local pos = f:seek()
+    assert.equal(pos, 9)
 end
 
 function testcase.read_with_offset()


### PR DESCRIPTION
This pull request addresses a bug in the `readn_lua` function where an incorrect buffer length was set on read errors, and adds new tests to cover this and related file reading behaviors. The most important changes are grouped below.

### Bug Fixes

* Fixed `readn_lua` so that `res.len` is only set when the read operation succeeds, preventing invalid buffer lengths on error (previously, a failed read would set `res.len` to `(size_t)-1`, which could cause a crash).

### Test Coverage Improvements

* Added `testcase.read_with_count_error` to verify that reading from a closed file correctly returns an error and does not crash due to invalid buffer length.
* Added `testcase.read_interleaved` to ensure that alternating between Lua's file:read and the custom `read` function works as expected, and that file position is correctly maintained.