### PR TITLE
Refactor read helpers to fix correctness and memory safety

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,7 @@ jobs:
         apt-get install lcov -y
         luarocks install testcase
         luarocks install io-fileno
+        luarocks install os-pipe
     -
       name: Run Test
       run: |

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Reads data from the specified file handle or file descriptor.
 
 - `file:file*|integer`: a file handle or a file descriptor.
 - `count:integer`: the number of bytes to read. if the `count` is not specified, then it will be read until the end of the file. (default: `nil`)
-- `offset:integer`: the offset in bytes from the beginning of the file to start reading. if the `offset` is specified, then the file position will be moved to the specified offset before reading. (default: `nil`)
+- `offset:integer`: the offset in bytes from the beginning of the file to start reading. if the `offset` is specified, `pread(2)` is used and the file position is not modified. (default: `nil`)
 
 **Returns**
 
-- `data:string`: read data.
-- `err:any`: error object.
-- `again:boolean`: `true` if the read operation is incomplete (read syscall returned `EAGAIN`, `EWOULDBLOCK`, or `EINTR`) and the `data` is not available.
+- `data:string`: read data. may be non-`nil` even when `err` is non-`nil` or `again` is `true` (see below).
+- `err:any`: error object. if `data` is also non-`nil`, partial data was accumulated before the error; the fd position has already advanced past those bytes, so they cannot be recovered by a retry.
+- `again:boolean`: `true` if the read syscall returned `EAGAIN`, `EWOULDBLOCK`, or `EINTR`. if `data` is non-`nil`, partial data was accumulated before the interruption and more data may arrive later; if `data` is `nil`, no bytes were read and the operation should be retried.
 
 
 ## Usage
@@ -46,8 +46,16 @@ local f = assert(io.open('./test.txt'))
 local data, err, again = read(f, 10)
 if data then
     print(data)
+    if again then
+        -- partial data: EAGAIN/EINTR occurred; more data may arrive
+        print('partial read, try again for more')
+    elseif err then
+        -- partial data: error occurred after reading some bytes; fd has
+        -- already advanced past them and they cannot be recovered by a retry
+        print('partial read error:', err)
+    end
 elseif again then
-    print('read syscall returned EAGAIN or EWOULDBLOCK')
+    print('read syscall returned EAGAIN, EWOULDBLOCK or EINTR')
 elseif err then
     print('read syscall is failed:', err)
 else

--- a/src/read.c
+++ b/src/read.c
@@ -34,212 +34,234 @@
 # define LUA_OK 0
 #endif
 
-typedef struct {
-    FILE *fp;
-    int fd;
-    off_t offset;
-    char *buf;
-    size_t len;
-    int err;
-} read_result_t;
+// buffer prep macro (Lua version-aware)
+#if LUA_VERSION_NUM > 501
+# define DEFAULT_BUFSIZE   ((size_t)(1024 * 16))
+# define prepbuf(L, b, sz) luaL_prepbuffsize((b), (sz))
+#else
+// On Lua 5.1, luaL_prepbuffer caps the buffer at LUAL_BUFFERSIZE.
+# define DEFAULT_BUFSIZE   ((size_t)LUAL_BUFFERSIZE)
+# define prepbuf(L, b, sz) luaL_prepbuffer(b)
+#endif
 
-static int pushlstring(lua_State *L)
+// Returns the buffer size to use for a single syscall: count bytes for
+// fixed-length reads, DEFAULT_BUFSIZE for read-all.  On Lua 5.1, the result
+// is capped at LUAL_BUFFERSIZE because luaL_prepbuffer allocates no more.
+static inline size_t clamp_bufsize(lua_Integer count)
 {
-    read_result_t *res = (read_result_t *)lua_topointer(L, 1);
-
-    lua_settop(L, 0);
-    if (res->len) {
-        lua_pushlstring(L, res->buf, res->len);
-        return 1;
+    size_t sz = (count > 0) ? (size_t)count : DEFAULT_BUFSIZE;
+#if LUA_VERSION_NUM <= 501
+    if (sz > (size_t)LUAL_BUFFERSIZE) {
+        sz = (size_t)LUAL_BUFFERSIZE;
     }
-
-    if (res->err) {
-        // got error
-        if (res->err == EAGAIN || res->err == EWOULDBLOCK ||
-            res->err == EINTR) {
-            lua_pushnil(L);
-            lua_pushnil(L);
-            lua_pushboolean(L, 1);
-            return 3;
-        }
-        // got error
-        lua_pushnil(L);
-        lua_errno_new(L, res->err,
-                      (res->err == ENOMEM) ? "read.alloc" : "read");
-        return 2;
-    }
-    // eof
-    return 0;
+#endif
+    return sz;
 }
 
-static int pushresult(lua_State *L, read_result_t *res)
-{
-    int rv = 0;
+typedef struct {
+    int fd;
+    FILE *fp;          // non-NULL only for read(2)+FILE* to sync position after
+    lua_Integer count; // -1=read-all, 0=zero-byte, >0=fixed-length
+    off_t offset;      //  0 for read(2), user-provided for pread(2)
+    ssize_t (*readfn)(int, void *, size_t, off_t);
+} read_ctx_t;
 
-    // only sync FILE* position when using read() (not pread())
-    if (res->fp && res->offset < 0 && res->len > 0) {
-        if (fseek(res->fp, lseek(res->fd, 0, SEEK_CUR), SEEK_SET) != 0) {
-            // fseek error
-            free(res->buf);
+// do_read: read(2) wrapper with pread(2)-compatible signature (offset ignored)
+static inline ssize_t do_read(int fd, void *buf, size_t nbyte, off_t offset)
+{
+    (void)offset;
+    return read(fd, buf, nbyte);
+}
+
+// sync_fp: resync FILE* position to the current fd position after read(2).
+// Non-seekable fds (pipes, sockets) return -1 from lseek; skip the sync.
+// Returns 0 on success or when skipped, -1 on fseek failure (errno is set).
+static int sync_fp(read_ctx_t *ctx)
+{
+    if (ctx->fp) {
+        off_t pos = lseek(ctx->fd, 0, SEEK_CUR);
+        if (pos >= 0) {
+            return fseek(ctx->fp, pos, SEEK_SET);
+        }
+    }
+    return 0; // non-seekable fd; no position to sync
+}
+
+static inline int push_read_result(lua_State *L, read_ctx_t *ctx,
+                                   luaL_Buffer *b, size_t len, int err)
+{
+    if (len > 0) {
+        if (sync_fp(ctx) != 0) {
+            lua_settop(L, 0);
             lua_pushnil(L);
             lua_errno_new(L, errno, "read.fseek");
             return 2;
         }
+        luaL_pushresult(b);
+        if (!err) {
+            return 1;
+        }
+    } else if (!err) {
+        return 0; // EOF
+    } else {
+        lua_settop(L, 0);
+        lua_pushnil(L);
     }
 
-    // call pushlstring function with pcall
-    lua_settop(L, 0);
-    lua_pushcclosure(L, pushlstring, 0);
-    lua_pushlightuserdata(L, res);
-    rv = lua_pcall(L, 1, LUA_MULTRET, 0);
-    free(res->buf);
+    // push error
+    if (err == EAGAIN || err == EWOULDBLOCK || err == EINTR) {
+        lua_pushnil(L);
+        lua_pushboolean(L, 1);
+        return 3;
+    }
+    lua_errno_new(L, err, "read");
+    return 2;
+}
 
-    switch (rv) {
+/**
+ * pcall_readfn_lua - unified read helper dispatched via lua_pcall.
+ * Stack on entry: 1=read_ctx_t lightuserdata
+ * count == -1: read-all loop (nremain wraps to SIZE_MAX; stops on EOF)
+ * count ==  0: zero-byte probe, returns ""
+ * count  > 0:  reads exactly count bytes (retries on short read)
+ * ctx->readfn selects read(2) (via do_read) or pread(2).
+ * cur starts at ctx->offset and advances per each successful read; do_read
+ * ignores the offset argument (kernel manages position).
+ * On error (n < 0) with no prior data:
+ *   returns nil, nil, true  — EAGAIN/EWOULDBLOCK/EINTR
+ *   returns nil, err        — other errors
+ * On error (n < 0) with prior data (Go-style: consume what was read):
+ *   returns data, nil, true — EAGAIN/EWOULDBLOCK/EINTR; more data may arrive
+ *   returns data, err       — other errors; fd has advanced past those bytes
+ * On EOF  (n == 0): cur > ctx->offset means at least one byte was read.
+ * ctx->fp non-NULL triggers FILE* position sync after read(2).
+ */
+static int pcall_readfn_lua(lua_State *L)
+{
+    read_ctx_t *ctx = (read_ctx_t *)lua_touserdata(L, 1);
+    int fd          = ctx->fd;
+    off_t cur       = ctx->offset;
+    size_t bsize    = clamp_bufsize(ctx->count);
+    size_t nremain  = (size_t)ctx->count;
+    char *buf       = NULL;
+    ssize_t n       = 0;
+    luaL_Buffer b;
+
+    if (ctx->count == 0) {
+        char dummy;
+        if (ctx->readfn(fd, &dummy, 0, cur) < 0) {
+            return push_read_result(L, ctx, NULL, 0, errno);
+        }
+        // push empty string for zero-byte probe success
+        lua_pushlstring(L, "", 0);
+        return 1;
+    }
+
+    luaL_buffinit(L, &b);
+RETRY:
+    if (bsize > nremain) {
+        bsize = nremain;
+    }
+    buf   = prepbuf(L, &b, bsize);
+    errno = 0;
+    n     = ctx->readfn(fd, buf, bsize, cur);
+    if (n > 0) {
+        luaL_addsize(&b, (size_t)n);
+        cur += (off_t)n;
+        nremain -= (size_t)n;
+        if (nremain > 0) {
+            goto RETRY;
+        }
+    }
+
+    return push_read_result(L, ctx, &b, (size_t)(cur - ctx->offset), errno);
+}
+
+static int read_lua(lua_State *L)
+{
+    struct stat st;
+    read_ctx_t ctx = {
+        .fd     = -1,
+        .fp     = NULL,
+        .count  = -1, // default to read-all; overridden by arg2 if provided
+        .offset = 0,  // overridden below
+    };
+
+    if (lauxh_isint(L, 1)) {
+        ctx.fd = lauxh_checkint(L, 1);
+    } else if (!(ctx.fp = lauxh_checkfile(L, 1))) {
+        // file has been closed; report EBADF immediately
+        lua_pushnil(L);
+        lua_errno_new(L, EBADF, "read");
+        return 2;
+    } else if (fflush(ctx.fp) != 0 && errno != EBADF) {
+        // NOTE: ignore EBADF which means the FILE* is not opened for writing
+        lua_pushnil(L);
+        lua_errno_new(L, errno, "read.fflush");
+        return 2;
+    } else {
+        ctx.fd = fileno(ctx.fp);
+    }
+
+    // resolve count: nil/absent → -1 (read-all); negative explicit → EINVAL
+    if (!lua_isnoneornil(L, 2)) {
+        ctx.count = lauxh_checkinteger(L, 2);
+        if (ctx.count < 0) {
+            lua_pushnil(L);
+            lua_errno_new(L, EINVAL, "read");
+            return 2;
+        }
+    }
+
+    // fstat optimisation: for regular files with read-all, use file size as a
+    // fixed-length hint so the helper issues one syscall instead of looping.
+    if (ctx.count < 0 && fstat(ctx.fd, &st) == 0 && S_ISREG(st.st_mode) &&
+        st.st_size > 0) {
+        ctx.count = (lua_Integer)st.st_size;
+    }
+
+    // get offset: -1 for current fd position (read), >=0 for pread
+    ctx.offset = lauxh_optinteger(L, 3, -1);
+    if (ctx.offset >= 0) {
+        ctx.readfn = pread;
+        ctx.fp     = NULL; // no FILE* sync needed for pread
+    } else {
+        ctx.readfn = do_read;
+        ctx.offset =
+            0; // do_read ignores offset; start at 0 so cur > ctx->offset
+               // after any successful read (used as "anything read?" check)
+    }
+
+    lua_settop(L, 1);
+    lua_pushcfunction(L, pcall_readfn_lua);
+    lua_pushlightuserdata(L, &ctx);
+
+    switch (lua_pcall(L, 1, LUA_MULTRET, 0)) {
     case LUA_OK:
-        // return values are already pushed to the stack
-        return lua_gettop(L);
+        return lua_gettop(L) - 1;
 
     default:
-        // NOTE: In LuaJIT and Lua 5.3 does not return LUA_ERRMEM error if
-        // memory allocation fails. so, it should check the error message to
-        // determine the error type that is memory allocation error or not.
+        // NOTE: LuaJIT and Lua 5.3 do not return LUA_ERRMEM on allocation
+        // failure; detect by inspecting the error message instead.
 #if LUA_VERSION_NUM == 503
         if (!strstr(lua_tostring(L, -1), "not enough memory"))
 #elif defined(LUA_LJDIR)
         if (!strstr(lua_tostring(L, -1), "length overflow"))
 #endif
         {
-            // otherwise, push nil and runtime error message
             lua_pushnil(L);
             lua_pushvalue(L, -2);
             lua_error_new(L, -1);
             return 2;
         }
+        // fall through to LUA_ERRMEM
 
     case LUA_ERRMEM:
-        // memory allocation error
         lua_pushnil(L);
         lua_errno_new_with_message(L, ENOMEM, "read.alloc",
                                    lua_tostring(L, -2));
         return 2;
     }
-}
-
-static int readn_lua(lua_State *L, FILE *fp, int fd, size_t count, off_t offset)
-{
-    read_result_t res = {
-        .fp     = fp,
-        .fd     = fd,
-        .offset = offset,
-        .buf    = malloc(count),
-        .len    = 0,
-        .err    = 0,
-    };
-    ssize_t nread = 0;
-
-    if (!res.buf) {
-        // malloc error
-        lua_pushnil(L);
-        lua_errno_new(L, errno, "read.alloc");
-        return 2;
-    }
-
-    nread = (offset < 0) ? read(fd, res.buf, count) :
-                           pread(fd, res.buf, count, offset);
-    if (nread > 0) {
-        res.len = (size_t)nread;
-    } else if (nread < 0) {
-        res.err = errno;
-    }
-    return pushresult(L, &res);
-}
-
-static int readall_lua(lua_State *L, FILE *fp, int fd, off_t offset)
-{
-    size_t allocsize  = 1024 * 16; // 16KB per allocation
-    size_t buflen     = allocsize;
-    read_result_t res = {
-        .fp     = fp,
-        .fd     = fd,
-        .offset = offset,
-        .buf    = malloc(allocsize),
-        .len    = 0,
-        .err    = 0,
-    };
-    ssize_t nread = 0;
-    size_t ntotal = 0;
-
-    if (!res.buf) {
-        // malloc error
-        lua_pushnil(L);
-        lua_errno_new(L, errno, "read.alloc");
-        return 2;
-    }
-
-RETRY:
-    nread = (offset < 0) ?
-                read(fd, res.buf + ntotal, buflen - ntotal) :
-                pread(fd, res.buf + ntotal, buflen - ntotal, offset + ntotal);
-    if (nread > 0) {
-        ntotal += (size_t)nread;
-        if (ntotal == buflen) {
-            // need to expand buffer
-            size_t new_buflen = buflen + allocsize;
-            char *new_buf     = realloc(res.buf, new_buflen);
-            if (new_buf) {
-                res.buf = new_buf;
-                buflen  = new_buflen;
-                goto RETRY;
-            }
-            // realloc error
-            res.err = errno;
-        }
-    } else if (nread == -1) {
-        res.err = errno;
-    }
-
-    res.len = ntotal;
-    return pushresult(L, &res);
-}
-
-static int read_lua(lua_State *L)
-{
-    struct stat st;
-    FILE *fp     = NULL;
-    int fd       = -1;
-    size_t count = 0;
-    off_t offset = 0;
-
-    if (lauxh_isint(L, 1)) {
-        // check fd
-        fd = lauxh_checkint(L, 1);
-    } else if (!(fp = lauxh_checkfile(L, 1))) {
-        fd = -1;
-    } else if (fflush(fp) != 0 && errno != EBADF) {
-        // failed to flush FILE* buffer
-        // NOTE: ignore EBADF error which means the FILE* is not opened for
-        // writing
-        lua_pushnil(L);
-        lua_errno_new(L, errno, "read.fflush");
-        return 2;
-    } else {
-        // get fd from FILE*
-        fd = fileno(fp);
-    }
-
-    // get file size if regular file
-    if (fstat(fd, &st) == 0 && S_ISREG(st.st_mode)) {
-        count = st.st_size;
-    }
-    // get count
-    count  = lauxh_optint(L, 2, count);
-    // get offset: -1 for current position, >=0 for absolute offset
-    offset = lauxh_optint(L, 3, -1);
-
-    if (count > 0) {
-        return readn_lua(L, fp, fd, count, offset);
-    }
-    return readall_lua(L, fp, fd, offset);
 }
 
 LUALIB_API int luaopen_io_read(lua_State *L)

--- a/test/read_test.lua
+++ b/test/read_test.lua
@@ -1,6 +1,7 @@
 local testcase = require('testcase')
 local assert = require('assert')
 local fileno = require('io.fileno')
+local pipe = require('os.pipe')
 local read = require('io.read')
 
 function testcase.readall()
@@ -107,6 +108,144 @@ function testcase.read_interleaved()
 
     local pos = f:seek()
     assert.equal(pos, 9)
+end
+
+function testcase.read_with_zero_count()
+    local f = assert(io.tmpfile())
+    f:write('hello')
+    f:seek('set')
+
+    -- test that read(f, 0) returns empty string
+    local data, err, again = read(f, 0)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(data, '')
+
+    -- verify cursor hasn't moved
+    local pos = f:seek()
+    assert.equal(pos, 0)
+
+    -- test that read(fd, 0) returns empty string
+    local fd = fileno(f)
+    data, err, again = read(fd, 0)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(data, '')
+
+    -- test that return error on closed file (EBADF)
+    f:close()
+    data, err, again = read(f, 0)
+    assert.is_nil(data)
+    assert.is_nil(again)
+    assert.match(err, 'EBADF')
+end
+
+function testcase.read_with_negative_count()
+    local f = assert(io.tmpfile())
+    f:write('hello')
+    f:seek('set')
+
+    -- test that read(f, -1) returns nil and EINVAL
+    local data, err, again = read(f, -1)
+    assert.is_nil(data)
+    assert.is_nil(again)
+    assert.match(err, 'EINVAL')
+
+    f:close()
+end
+
+function testcase.readall_with_offset()
+    local f = assert(io.tmpfile())
+    f:write('hello world')
+    f:seek('set')
+
+    -- test read-all from offset 6 (pread loop, cursor must not change)
+    local data, err, again = read(f, nil, 6)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(data, 'world')
+
+    -- verify cursor hasn't changed (was 0 after seek('set'))
+    local pos = f:seek()
+    assert.equal(pos, 0)
+
+    -- test read-all from offset at EOF returns nil
+    data, err, again = read(f, nil, 11)
+    assert.is_nil(data)
+    assert.is_nil(err)
+    assert.is_nil(again)
+
+    f:close()
+end
+
+function testcase.read_from_pipe_chunked()
+    -- Write 5 bytes, sleep briefly, then write 6 more bytes.  This forces a
+    -- short read on the first attempt.  The nremain-based RETRY must pick up
+    -- the remaining bytes; the old (n == bsize) condition would have returned
+    -- only the first 5 bytes and missed the rest.
+    local fp = assert(io.popen("printf 'hello'; sleep 0.1; printf ' world'"))
+    local data, err, again = read(fp, 11)
+    fp:close()
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(data, 'hello world')
+end
+
+function testcase.read_from_invalid_fd_errors()
+    -- read(bad_int_fd, n) dispatches directly without FILE* validation;
+    -- the first syscall returns EBADF with no bytes read, exercising the
+    -- len==0, err!=0 branch in push_read_result (lines 107-108, 117-118).
+    local data, err, again = read(99999, 10)
+    assert.is_nil(data)
+    assert.is_nil(again)
+    assert.match(err, 'EBADF')
+
+    -- read(bad_int_fd, 0) exercises the count==0 readfn-failure path
+    -- (line 153), which also falls through to the same push_read_result branch.
+    data, err, again = read(99999, 0)
+    assert.is_nil(data)
+    assert.is_nil(again)
+    assert.match(err, 'EBADF')
+end
+
+-- On Lua 5.1, LUAL_BUFFERSIZE == BUFSIZ == 1024.  Requesting count > 1024
+-- causes clamp_bufsize() to cap bsize at LUAL_BUFFERSIZE (lines 55-56) so
+-- the loop issues multiple syscalls to reach the total.
+function testcase.read_with_large_count_clamp()
+    local f = assert(io.tmpfile())
+    f:write(string.rep('a', 1025))
+    f:seek('set')
+
+    local data, err, again = read(f, 1025)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(#data, 1025)
+
+    f:close()
+end
+
+-- Non-blocking read exercises the EAGAIN/EWOULDBLOCK path that returns
+-- again=true (lines 113-115).  os.pipe(true) creates a non-blocking pipe.
+function testcase.read_with_again()
+    local r, w = pipe(true)
+    local fd = r:fd()
+
+    -- empty non-blocking pipe: EAGAIN with no data → nil, nil, true
+    local data, err, again = read(fd, 10)
+    assert.is_nil(data)
+    assert.is_nil(err)
+    assert.is_true(again)
+
+    -- write 5 bytes then read 10: short read followed by EAGAIN →
+    -- partial data, nil, true
+    w:write('hello')
+    data, err, again = read(fd, 10)
+    assert.equal(data, 'hello')
+    assert.is_nil(err)
+    assert.is_true(again)
+
+    r:close()
+    w:close()
 end
 
 function testcase.read_with_offset()


### PR DESCRIPTION
This pull request makes significant improvements to the `io.read` Lua module, focusing on more robust and consistent read semantics, better error handling, and enhanced test coverage. The changes clarify how partial reads and errors are handled, add support for new edge cases (such as zero and negative counts), and improve documentation and tests to match the new behavior.

**Key changes include:**

### Read Semantics & Error Handling

* Refactored the C implementation in `src/read.c` to unify and clarify how reads are performed, especially regarding partial reads, zero-byte reads, negative counts, and error conditions. Now, `pread(2)` is used when an offset is specified, ensuring the file position is not modified, and the return values consistently indicate partial data and errors in a Go-style manner.
* Added explicit handling for zero and negative count arguments: `read(f, 0)` returns an empty string without advancing the file position, while negative counts return an EINVAL error.

### Documentation Updates

* Updated the `README.md` to clarify the semantics of the `offset` parameter, the meaning of return values (especially for partial reads and errors), and to provide more detailed usage examples that match the new implementation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R36) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R49-R58)

### Test Coverage

* Expanded the test suite in `test/read_test.lua` to cover new edge cases, including zero and negative count reads, reading with offsets (and ensuring file position is preserved), partial reads from pipes, error cases with invalid file descriptors, and behavior with large counts that exceed buffer sizes.
* Added dependency on `os-pipe` for non-blocking pipe tests. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R59) [[2]](diffhunk://#diff-25de1ca4d8f9fa46628778f3c60194cf79a95936482d15f15b3485f8d409a9aaR4)

---

**Most important changes:**

#### Read Semantics and Implementation

* Refactored `src/read.c` to use a unified read context, handle partial reads and errors consistently, support zero and negative counts, and use `pread(2)` for offset reads without modifying file position.

#### Documentation

* Clarified in `README.md` how the `offset` parameter works (uses `pread(2)` and does not modify file position), and detailed the meaning of `data`, `err`, and `again` return values for all edge cases.
* Updated usage examples in `README.md` to illustrate handling of partial reads, errors, and the new return value semantics.

#### Test Suite

* Added comprehensive tests in `test/read_test.lua` for zero/negative counts, offset reads, partial reads from pipes, invalid file descriptors, and buffer clamping for large counts.
* Added `os-pipe` as a test dependency for non-blocking pipe tests. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R59) [[2]](diffhunk://#diff-25de1ca4d8f9fa46628778f3c60194cf79a95936482d15f15b3485f8d409a9aaR4)